### PR TITLE
use unique_ptr to handle a resource created with malloc

### DIFF
--- a/libcommonutil/commonutil.cpp
+++ b/libcommonutil/commonutil.cpp
@@ -31,6 +31,8 @@ THE SOFTWARE.
 #include "framework.h"
 #include "commonutil.h"
 
+#include<memory>
+
 #pragma comment(lib, "version.lib") 
 
 bool
@@ -49,9 +51,9 @@ GetProductVersionInfo(wstring& strProductName, wstring& strProductVersion,
 		return false;
 	}
 
-	void* pVersionResource = NULL;
+	std::unique_ptr<void, void(*)(void*)> pVersionResourceHandle(malloc(vSize), free);
 
-	pVersionResource = malloc(vSize);
+	void* pVersionResource = pVersionResourceHandle.get();
 
 	if (pVersionResource == NULL)
 	{
@@ -59,7 +61,6 @@ GetProductVersionInfo(wstring& strProductName, wstring& strProductVersion,
 	}
 
 	if (!GetFileVersionInfo(fullPath, NULL, vSize, pVersionResource)) {
-		free(pVersionResource);
 		return false;
 	}
 
@@ -105,20 +106,16 @@ GetProductVersionInfo(wstring& strProductName, wstring& strProductVersion,
 		!VerQueryValue(pVersionResource, (L"\\StringFileInfo\\" + lang + L"\\ProductVersion").c_str(), &pvProductVersion, &iProductVersionLen) ||
 		!VerQueryValue(pVersionResource, (L"\\StringFileInfo\\" + lang + L"\\LegalCopyright").c_str(), &pvLegalCopyright, &iLegalCopyrightLen))
 	{
-		free(pVersionResource);
 		return false;
 	}
 
 	if (iProductNameLen < 1 || iProductVersionLen < 1 || iLegalCopyrightLen < 1) {
-		free(pVersionResource);
 		return false;
 	}
 
 	strProductName = (LPCTSTR)pvProductName;
 	strProductVersion = (LPCTSTR)pvProductVersion;
 	strLegalCopyright = (LPCTSTR)pvLegalCopyright;
-
-	free(pVersionResource);
 
 	return true;
 }

--- a/libcommonutil/commonutil.cpp
+++ b/libcommonutil/commonutil.cpp
@@ -51,7 +51,7 @@ GetProductVersionInfo(wstring& strProductName, wstring& strProductVersion,
 		return false;
 	}
 
-	std::unique_ptr<void, void(*)(void*)> pVersionResourceHandle(malloc(vSize), free);
+	auto pVersionResourceHandle = cppcryptfs::unique_rsc(malloc, free, vSize);
 
 	void* pVersionResource = pVersionResourceHandle.get();
 


### PR DESCRIPTION

I randomly clicked this source file and noticed you are doing manual memory management and these[1][2] code paths are leaking memory when taken and i though using unique_ptr to let the language deal with managing the resource is a better alternative.

[1] https://github.com/bailey27/cppcryptfs/blob/90c79ea009b2183948c04d7ba679737324b6727b/libcommonutil/commonutil.cpp#L81

[2] https://github.com/bailey27/cppcryptfs/blob/90c79ea009b2183948c04d7ba679737324b6727b/libcommonutil/commonutil.cpp#L90