### PR TITLE
Fix: conflict between Raw64 and PlaintextNames flags in config

### DIFF
--- a/libcppcryptfs/config/cryptconfig.cpp
+++ b/libcppcryptfs/config/cryptconfig.cpp
@@ -872,8 +872,11 @@ bool CryptConfig::create(const WCHAR *path, const WCHAR *specified_config_file_p
 	if (siv)
 		m_AESSIV = true;
 
-	// Raw64 and HKDF default to true
-	m_Raw64 = true;
+	// Raw64 defaults to true, but must be disabled if PlaintextNames is active
+    // (PlaintextNames implies filenames are not encrypted, so Base64 encoding is conflicting)
+    m_Raw64 = !m_PlaintextNames;
+
+	// HKDF default to true
 	m_HKDF = true;
 
 	if (reverse)


### PR DESCRIPTION
When creating a new volume with `PlaintextNames` enabled, the generated configuration file (`gocryptfs.conf`) incorrectly sets the `Raw64` flag.
`Raw64` (Base64 encoding for filenames) and `PlaintextNames` (no filename encryption) are mutually exclusive in gocryptfs, and enabling both causes compatibility issues.


### The Issue (Before Fix)
Currently, creating a config with `PlaintextNames` results in the following conflicting flags:

```json
// Generated by current version
{
	"Creator": "cppcryptfs v1.4.4.7",
	"EncryptedKey": "Z4Ao3yTqWZrCHFUs9Nuxy7Im2wAkvrD3MoNn1+p15xg9bWWz8cOrnxcgJlcABuqHhVw1/wJ1CZOD1F3YL2uSMA==",
	"ScryptObject": {
		"Salt": "7/GUVQtO+BbGXueekEZf1N6oNBxaxKMqrF5x57oF5Qk=",
		"N": 65536,
		"R": 8,
		"P": 1,
		"KeyLen": 32
	},
	"Version": 2,
	"VolumeName": "",
	"FsFeatureDisableMask": "00000",
	"FeatureFlags": [
		"PlaintextNames",
		"HKDF",
		"Raw64", <-- conflict
		"GCMIV128"
	]
}
```
```bash
gocryptfs --version
gocryptfs 2.4.0; go-fuse 2.4.2; 2025-06-24 go1.22.2 linux/amd64

gocryptfs . ~/test_win_mount
Cannot open config file: PlaintextNames conflicts with Raw64 feature flag

gocryptfs -info .
Loading config file failed: PlaintextNames conflicts with Raw64 feature flag

```
### The Fix
I modified `CryptConfig::create` to explicitly disable the `Raw64` flag when `PlaintextNames` is active. This ensures cppcryptfs generates configuration files that are compatible with gocryptfs validation rules.
I used `m_PlaintextNames` instead of the function argument to correctly respect the precedence logic (e.g., the EMENames check) defined earlier in the function.
### Verification (After Fix)
After applying the fix, the generated configuration file is clean and correct:

```json
// Generated with this PR
{
	"Creator": "cppcryptfs v1.4.4.7",
	"EncryptedKey": "QB+Z5YyAtRLv7KUitiOIQ1JmpdS0RYrIq5/njp7mP0p9W+VXawWPvRnALi8rXE2pV5OofktKggDz9b4B4+YTjA==",
	"ScryptObject": {
		"Salt": "D1pQ9UUU6bCnTP2UxSs3Zr0j0vq+w0Ho76ToxeRLlsA=",
		"N": 65536,
		"R": 8,
		"P": 1,
		"KeyLen": 32
	},
	"Version": 2,
	"VolumeName": "",
	"FsFeatureDisableMask": "00000",
	"FeatureFlags": [
		"PlaintextNames",
		"HKDF",
		"GCMIV128"
	] // "Raw64" is removed.
}
```
Verified that gocryptfs now recognizes and mounts the volume without errors.